### PR TITLE
New keyboard button trigger type

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ $ npm test
 * [constructor(settings)](#constructorsettings)
 * [.use(middleware)](#usemiddleware)
 * [.command(triggers, ...middlewares)](#commandtriggers-middlewares)
+* [.button(triggers, ...middlewares)](#buttontriggers-middlewares)
 * [.event(triggers, ...middlewares)](#eventtriggers-middlewares)
 * [.on(...middlewares)](#onmiddlewares)
 * [.sendMessage(userId, message, attachment, keyboard, sticker)](#sendmessageuserid-message-attachment-keyboard-sticker)
@@ -114,6 +115,16 @@ Add middlewares with triggers for `message_new` event.
 
 ```javascript
 bot.command('start', (ctx) => {
+  ctx.reply('Hello!')
+})
+```
+
+### .button(triggers, ...middlewares)
+
+Add middlewares with triggers for button payload.
+
+```javascript
+bot.button([{ command: 'start' }, 'start'], (ctx) => {
   ctx.reply('Hello!')
 })
 ```

--- a/examples/keyboard.js
+++ b/examples/keyboard.js
@@ -25,4 +25,18 @@ bot.command('/mood', (ctx) => {
     ]));
 });
 
+bot.command('/stats', (ctx) => {
+  ctx.reply('Select the period of time:', null, Markup
+    .keyboard([
+      [
+        Markup.button('For month', 'primary', { command: 'stats', period: 'month' }),
+        Markup.button('For year', 'default', 'year'),
+      ],
+    ])
+    .oneTime());
+});
+
+bot.button({ command: 'stats', period: 'month' }, ctx => ctx.reply('For month'));
+bot.button('year', ctx => ctx.reply('For year'));
+
 bot.startPolling();

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,10 +1,11 @@
 const axios = require('axios');
 const { stringify } = require('querystring');
+const { VERSION } = require('./constants');
 
 module.exports = async function (method, settings = {}) {
   try {
     const { data } = await axios.post(`https://api.vk.com/method/${method}`, stringify({
-      v: 5.80,
+      v: VERSION,
       ...settings,
     }));
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -8,6 +8,12 @@ module.exports.WEB_HOOK_RESPONSES = {
   FAILED: 'error',
 };
 
+module.exports.TRIGGER_TYPES = {
+  EVENT: 'event',
+  TEXT: 'text',
+  PAYLOAD: 'payload',
+};
+
 module.exports.VERSION = '5.80';
 
 module.exports.KEYBOARD_COLUMNS_MAX = 4;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,13 @@
+module.exports.EVENT_TYPES = {
+  CONFIRMATION: 'confirmation',
+  NEW_MESSAGE: 'message_new',
+};
+
+module.exports.WEB_HOOK_RESPONSES = {
+  SUCCESS: 'ok',
+  FAILED: 'error',
+};
+
+module.exports.VERSION = '5.80';
+
+module.exports.KEYBOARD_COLUMNS_MAX = 4;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,25 @@
-const methods = require('./methods');
 const api = require('./api');
+const { TRIGGER_TYPES } = require('./constants');
 const { callExecute } = require('./utils');
+const {
+  command,
+  sendMessage,
+  startPolling,
+  use,
+  next,
+  execute,
+  webhookCallback,
+} = require('./methods');
+
+const PUBLIC_METHODS = {
+  api,
+  sendMessage,
+  startPolling,
+  use,
+  next,
+  execute,
+  webhookCallback,
+};
 
 class VkBot {
   constructor(settings) {
@@ -17,26 +36,30 @@ class VkBot {
       execute_timeout: 50,
     }, typeof settings === 'object' ? settings : { token: settings });
 
-    Object.entries({ ...methods, api, callExecute }).forEach(([key, method]) => {
+    Object.entries(PUBLIC_METHODS).forEach(([key, method]) => {
       this[key] = method.bind(this);
     });
 
     setInterval(() => {
-      this.callExecute(this.methods);
+      callExecute(this.methods);
       this.methods = [];
     }, settings.execute_timeout);
   }
 
+  command(triggers, ...middlewares) {
+    command.call(this, triggers, TRIGGER_TYPES.TEXT, ...middlewares);
+  }
+
   event(triggers, ...middlewares) {
-    this.command(triggers, ...middlewares);
+    command.call(this, triggers, TRIGGER_TYPES.EVENT, ...middlewares);
   }
 
   button(payloads, ...middlewares) {
-    this.command(payloads, 'payload', ...middlewares);
+    command.call(this, payloads, TRIGGER_TYPES.PAYLOAD, ...middlewares);
   }
 
   on(...middlewares) {
-    this.command([], ...middlewares);
+    command.call(this, [], TRIGGER_TYPES.TEXT, ...middlewares);
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,10 @@ class VkBot {
     this.command(triggers, ...middlewares);
   }
 
+  button(payloads, ...middlewares) {
+    this.command(payloads, 'payload', ...middlewares);
+  }
+
   on(...middlewares) {
     this.command([], ...middlewares);
   }

--- a/lib/markup.js
+++ b/lib/markup.js
@@ -1,4 +1,4 @@
-const KEYBOARD_COLUMNS_MAX = 4;
+const { KEYBOARD_COLUMNS_MAX } = require('./constants');
 
 class Markup {
   keyboard(buttons, options = { columns: KEYBOARD_COLUMNS_MAX }) {

--- a/lib/methods/command.js
+++ b/lib/methods/command.js
@@ -1,8 +1,14 @@
 const toArray = require('../utils/toArray');
 
 module.exports = function (_triggers, ...middlewares) {
-  const triggers = toArray(_triggers)
-    .map(item => (item instanceof RegExp ? item : item.toLowerCase()));
+  const triggers = toArray(_triggers);
+
+  let triggerType = 'text';
+
+  if (typeof middlewares[0] === 'string') {
+    triggerType = middlewares[0];
+    middlewares.splice(0, 1);
+  }
 
   middlewares.forEach((fn) => {
     const idx = this.middlewares.length;
@@ -10,6 +16,7 @@ module.exports = function (_triggers, ...middlewares) {
     this.middlewares.push({
       fn: ctx => fn(ctx, () => this.next(ctx, idx)),
       triggers,
+      triggerType,
     });
   });
 

--- a/lib/methods/command.js
+++ b/lib/methods/command.js
@@ -1,22 +1,29 @@
+const { TRIGGER_TYPES } = require('../constants');
 const toArray = require('../utils/toArray');
 
-module.exports = function (_triggers, ...middlewares) {
-  const triggers = toArray(_triggers);
+module.exports = function (triggers, type, ...middlewares) {
+  const isButton = type === TRIGGER_TYPES.PAYLOAD;
 
-  let triggerType = 'text';
+  const normalizedTriggers = toArray(triggers)
+    .map((item) => {
+      if (isButton && typeof item === 'object') {
+        return JSON.stringify(item);
+      }
 
-  if (typeof middlewares[0] === 'string') {
-    triggerType = middlewares[0];
-    middlewares.splice(0, 1);
-  }
+      if (typeof item === 'string') {
+        return item.toLowerCase();
+      }
+
+      return item;
+    });
 
   middlewares.forEach((fn) => {
     const idx = this.middlewares.length;
 
     this.middlewares.push({
       fn: ctx => fn(ctx, () => this.next(ctx, idx)),
-      triggers,
-      triggerType,
+      triggers: normalizedTriggers,
+      type,
     });
   });
 

--- a/lib/methods/execute.js
+++ b/lib/methods/execute.js
@@ -1,7 +1,9 @@
+const { VERSION } = require('../constants');
+
 module.exports = function (method, settings, callback = () => {}) {
   this.methods.push({
     code: `API.${method}(${JSON.stringify({
-      v: '5.80',
+      v: VERSION,
       ...settings,
     })})`,
     callback,

--- a/lib/methods/next.js
+++ b/lib/methods/next.js
@@ -1,16 +1,24 @@
 module.exports = function (ctx, idx = -1) {
   if (this.middlewares.length > idx + 1) {
-    const { fn, triggers } = this.middlewares[idx + 1];
+    const { fn, triggers, triggerType } = this.middlewares[idx + 1];
     const isTriggered = (triggers || []).some(
       (trigger) => {
         if (ctx.message.type === 'message_new' && trigger !== 'message_new') {
-          const message = (ctx.message.text || ctx.message.body || '').toLowerCase();
+          let message = ((triggerType === 'text'
+            ? (ctx.message.text || ctx.message.body)
+            : ctx.message[triggerType]) || '');
+
+          message = typeof message === 'string' ? message : JSON.stringify(message);
 
           if (trigger instanceof RegExp) {
             return trigger.test(message);
           }
+          if (trigger instanceof String) {
+            return message.toLowerCase() === trigger.toLowerCase()
+              || message.toLowerCase().startsWith(trigger.toLowerCase());
+          }
 
-          return message.startsWith(trigger);
+          return message === JSON.stringify(trigger);
         }
 
         return ctx.message.type === trigger;

--- a/lib/methods/next.js
+++ b/lib/methods/next.js
@@ -1,34 +1,40 @@
+const { TRIGGER_TYPES, EVENT_TYPES } = require('../constants');
+
 module.exports = function (ctx, idx = -1) {
   if (this.middlewares.length > idx + 1) {
-    const { fn, triggers, triggerType } = this.middlewares[idx + 1];
-    const isTriggered = (triggers || []).some(
-      (trigger) => {
-        if (ctx.message.type === 'message_new' && trigger !== 'message_new') {
-          let message = ((triggerType === 'text'
-            ? (ctx.message.text || ctx.message.body)
-            : ctx.message[triggerType]) || '');
+    const { fn, triggers, type } = this.middlewares[idx + 1];
 
-          message = typeof message === 'string' ? message : JSON.stringify(message);
-
-          if (trigger instanceof RegExp) {
-            return trigger.test(message);
-          }
-          if (trigger instanceof String) {
-            return message.toLowerCase() === trigger.toLowerCase()
-              || message.toLowerCase().startsWith(trigger.toLowerCase());
-          }
-
-          return message === JSON.stringify(trigger);
-        }
-
-        return ctx.message.type === trigger;
-      },
-    );
-
-    if (!triggers || (!triggers.length && ctx.message.type === 'message_new') || isTriggered) {
+    // common middleware
+    if (!triggers) {
       return fn(ctx);
     }
 
-    return this.next(ctx, idx + 1);
+    // text command without triggers
+    if (!triggers.length && ctx.message.type === EVENT_TYPES.NEW_MESSAGE) {
+      return fn(ctx);
+    }
+
+    // text or button command with triggers
+    const isTriggered = triggers.some((trigger) => {
+      if (ctx.message.type === EVENT_TYPES.NEW_MESSAGE && type === TRIGGER_TYPES.TEXT) {
+        const message = (ctx.message.text || ctx.message.body || '').toLowerCase();
+
+        return trigger instanceof RegExp
+          ? trigger.test(message)
+          : message.startsWith(trigger);
+      }
+
+      if (ctx.message.type === EVENT_TYPES.NEW_MESSAGE && type === TRIGGER_TYPES.PAYLOAD) {
+        return ctx.message.payload === trigger;
+      }
+
+      if (type === TRIGGER_TYPES.EVENT) {
+        return ctx.message.type === trigger;
+      }
+
+      return false;
+    });
+
+    return isTriggered ? fn(ctx) : this.next(ctx, idx + 1);
   }
 };

--- a/lib/methods/webhookCallback.js
+++ b/lib/methods/webhookCallback.js
@@ -1,23 +1,22 @@
 const Request = require('../request');
 const Context = require('../context');
-
-const CONFIRMATION_TYPE = 'confirmation';
+const { EVENT_TYPES, WEB_HOOK_RESPONSES } = require('../constants');
 
 module.exports = function (...args) {
   const request = new Request(...args);
 
   if (
-    request.body.type !== CONFIRMATION_TYPE
+    request.body.type !== EVENT_TYPES.CONFIRMATION
     && this.settings.secret
     && this.settings.secret !== request.body.secret
   ) {
-    request.body = 'error';
+    request.body = WEB_HOOK_RESPONSES.FAILED;
 
     return;
   }
 
-  if (request.body.type !== CONFIRMATION_TYPE) {
-    request.body = 'ok';
+  if (request.body.type !== EVENT_TYPES.CONFIRMATION) {
+    request.body = WEB_HOOK_RESPONSES.SUCCESS;
 
     return this.next(new Context(request.body, this));
   }

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -1,3 +1,5 @@
+const { EVENT_TYPES } = require('./constants');
+
 class Stage {
   constructor(...scenes) {
     this.scenes = {};
@@ -63,7 +65,7 @@ class Stage {
         },
       });
 
-      if (ctx.session.__scene && ctx.message.type === 'message_new') {
+      if (ctx.session.__scene && ctx.message.type === EVENT_TYPES.NEW_MESSAGE) {
         return this.enter(ctx);
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vk-bot-api",
-  "version": "2.4.8",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vk-bot-api",
-  "version": "2.4.8",
+  "version": "2.5.0",
   "description": "🤖 VK bot framework for Node.js, based on Bots Long Poll API and Callback API",
   "main": "lib/index.js",
   "scripts": {

--- a/test/triggers.test.js
+++ b/test/triggers.test.js
@@ -58,6 +58,17 @@ describe('triggers', () => {
       });
     });
 
+    it('should match text trigger without commands', (done) => {
+      bot.on(() => done());
+
+      bot.next({
+        message: {
+          type: 'message_new',
+          text: 'AJSDkj',
+        },
+      });
+    });
+
     it('should match text trigger', (done) => {
       bot.command('help', () => done());
 
@@ -80,11 +91,7 @@ describe('triggers', () => {
       });
     });
 
-    it('should match button trigger', (done) => {
-      bot.command({ command: 'start' }, () => {
-        throw new Error('Command was triggered');
-      });
-
+    it('should match button trigger with payload json', (done) => {
       bot.button({ command: 'start' }, () => {
         done();
       });
@@ -94,6 +101,20 @@ describe('triggers', () => {
           type: 'message_new',
           text: 'Start',
           payload: JSON.stringify({ command: 'start' }),
+        },
+      });
+    });
+
+    it('should match button trigger with payload string', (done) => {
+      bot.button('help', () => {
+        done();
+      });
+
+      bot.next({
+        message: {
+          type: 'message_new',
+          text: 'Start',
+          payload: 'help',
         },
       });
     });

--- a/test/triggers.test.js
+++ b/test/triggers.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const VkBot = require('../lib');
 
-const bot = new VkBot('TOKEN');
+const bot = new VkBot(process.env.TOKEN);
 
 describe('triggers', () => {
   beforeEach(() => {
@@ -9,7 +9,7 @@ describe('triggers', () => {
   });
 
   describe('unit', () => {
-    it('should define valid text trigger', () => {
+    it('should create text trigger', () => {
       bot.command('Start', () => {});
 
       expect(bot.middlewares[0]).to.be.an('object');
@@ -19,7 +19,7 @@ describe('triggers', () => {
       expect(bot.middlewares[0].triggers[0]).to.be.a('string');
     });
 
-    it('should define valid button trigger', () => {
+    it('should create button trigger', () => {
       bot.button({ command: 'start' }, () => {});
 
       expect(bot.middlewares[0]).to.be.an('object');
@@ -34,7 +34,19 @@ describe('triggers', () => {
 
   describe('e2e', () => {
     it('should match text trigger', (done) => {
+      bot.command('help', () => done());
+
+      bot.next({
+        message: {
+          type: 'message_new',
+          text: 'help me, please',
+        },
+      });
+    });
+
+    it('should match regex trigger', (done) => {
       bot.command(/[sс]t?a[Rр]t/g, () => done());
+
       bot.next({
         message: {
           type: 'message_new',
@@ -43,9 +55,9 @@ describe('triggers', () => {
       });
     });
 
-    it('should execute button trigger and not text', (done) => {
+    it('should match button trigger', (done) => {
       bot.command({ command: 'start' }, () => {
-        throw new Error('text trigger was called');
+        throw new Error('Command was triggered');
       });
 
       bot.button({ command: 'start' }, () => {

--- a/test/triggers.test.js
+++ b/test/triggers.test.js
@@ -1,0 +1,64 @@
+const { expect } = require('chai');
+const VkBot = require('../lib');
+
+const bot = new VkBot('TOKEN');
+
+describe('triggers', () => {
+  beforeEach(() => {
+    bot.middlewares = [];
+  });
+
+  describe('unit', () => {
+    it('should define valid text trigger', () => {
+      bot.command('Start', () => {});
+
+      expect(bot.middlewares[0]).to.be.an('object');
+      expect(bot.middlewares[0].fn).to.be.a('function');
+      expect(bot.middlewares[0].triggerType).to.be.a('string').and.equal('text');
+      expect(bot.middlewares[0].triggers).to.be.an('array').and.to.have.length(1);
+      expect(bot.middlewares[0].triggers[0]).to.be.a('string');
+    });
+
+    it('should define valid button trigger', () => {
+      bot.button({ command: 'start' }, () => {});
+
+      expect(bot.middlewares[0]).to.be.an('object');
+      expect(bot.middlewares[0].fn).to.be.a('function');
+      expect(bot.middlewares[0].triggerType).to.be.a('string').and.equal('payload');
+      expect(bot.middlewares[0].triggers).to.be.an('array').and.to.have.length(1);
+      expect(bot.middlewares[0].triggers[0]).to.be.an('object').and.satisfy(
+        value => JSON.stringify(value) === JSON.stringify({ command: 'start' }),
+      );
+    });
+  });
+
+  describe('e2e', () => {
+    it('should match text trigger', (done) => {
+      bot.command(/[sс]t?a[Rр]t/g, () => done());
+      bot.next({
+        message: {
+          type: 'message_new',
+          text: 'сaRt',
+        },
+      });
+    });
+
+    it('should execute button trigger and not text', (done) => {
+      bot.command({ command: 'start' }, () => {
+        throw new Error('text trigger was called');
+      });
+
+      bot.button({ command: 'start' }, () => {
+        done();
+      });
+
+      bot.next({
+        message: {
+          type: 'message_new',
+          text: 'Start',
+          payload: JSON.stringify({ command: 'start' }),
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
This would allow us to define triggers for keyboard buttons. For example, bot sends keyboard ["Categories", "Help"] to user. Bot will able to handle it like this:

```javascript
bot.button('categories', (ctx) => {
  ctx.reply(categories.map(item => item.name).join('\n'));
});

bot.button('help', (ctx) => {
  ctx.reply('My commands are Categories and Help. Try them now!');
})
```