### PR TITLE
Accept an array of users in sendMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ Send message to user.
 // Simple usage
 bot.sendMessage(145003487, 'Hello!', 'photo1_1')
 
+// Multiple recipients
+bot.sendMessage([145003487, 145003488], 'Hello!', 'photo1_1')
+
 // Advanced usage
 bot.sendMessage(145003487, {
   message: 'Hello!',

--- a/lib/methods/sendMessage.js
+++ b/lib/methods/sendMessage.js
@@ -19,7 +19,7 @@ module.exports = function (userId, ...args) {
           message,
           attachment: toArray(attachment).join(','),
           sticker_id: sticker,
-          keyboard: keyboard ? keyboard.toJSON() : null,
+          keyboard: keyboard ? keyboard.toJSON() : undefined,
         },
     ),
   );

--- a/lib/methods/sendMessage.js
+++ b/lib/methods/sendMessage.js
@@ -3,11 +3,15 @@ const toArray = require('../utils/toArray');
 module.exports = function (userId, ...args) {
   const [message, attachment, keyboard, sticker] = args;
 
+  if (Array.isArray(userId) && userId.length > 100) {
+    throw new Error('Message can\'t be sent to more than 100 recipients.');
+  }
+
   this.execute(
     'messages.send',
     Object.assign(
-      userId < 2000000000
-        ? { user_ids: toArray(userId).join(',') }
+      Array.isArray(userId)
+        ? { user_ids: userId.join(',') }
         : { peer_id: userId },
       typeof args[0] === 'object'
         ? args[0]


### PR DESCRIPTION
- A message would be sent using `peer_id` instead of `user_ids` with a single element.
- sendMessage now accept an array of `user_ids`.

According to [documentation](https://vk.com/dev/messages.send),  `peer_id` can be used as a destination for a single user, chat room, or a community.

Fix error for empty keyboard
```
{"method":"messages.send","error_code":911,"error_msg":"Keyboard format is invalid: keyboard should be array"}
Execute Error: {"method":"execute","error_code":911,"error_msg":"Keyboard format is invalid: keyboard should be array"}
```