### PR TITLE
Add return statement to handle promise execution properly

### DIFF
--- a/lib/methods/sendMessage.js
+++ b/lib/methods/sendMessage.js
@@ -7,7 +7,7 @@ module.exports = function (userId, ...args) {
     throw new Error('Message can\'t be sent to more than 100 recipients.');
   }
 
-  this.execute(
+  return this.execute(
     'messages.send',
     Object.assign(
       Array.isArray(userId)


### PR DESCRIPTION
When this is the case: you send message to user which did not give you permission to send him messages. This causes an unhandled promise exception, which is not handled by try-catch:

```
(node:23) UnhandledPromiseRejectionWarning: #<Object>
(node:23) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: xx)
```

