### PR TITLE
Append group_id and event_id into context

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,11 +1,14 @@
 class Context {
-  constructor({ type, object: update }, bot) {
+  constructor({ type, object: update, group_id, event_id }, bot) {
     if (update.message) {
       this.message = { ...update.message, type };
       this.client_info = update.client_info;
     } else {
       this.message = { ...update, type };
     }
+
+    this.group_id = group_id;
+    this.event_id = event_id;
 
     this.bot = bot;
   }


### PR DESCRIPTION
Motivation

I want to know `group_id` from the received message of the user.
It comes with the body payload but not involved in further processing.

Possible stoppers

I am not sure that group_id is a universal field for all message types.